### PR TITLE
Decouple any visibility from topics

### DIFF
--- a/src/components/TheTopicPanel.vue
+++ b/src/components/TheTopicPanel.vue
@@ -57,7 +57,7 @@ const filterSwitchLabel = computed(() => (schlagInfo.value
   : 'Nur im Kartenausschnitt sichtbare Themen'));
 
 watch(selectedTopic, (value) => {
-  showOverview.value = value !== 'none';
+  showOverview.value = value === 'any';
   topics.forEach((topic) => {
     topic.visible = topic.label === value;
   });

--- a/src/composables/useLayers.js
+++ b/src/composables/useLayers.js
@@ -36,7 +36,7 @@ function setLayerOpacity(mapboxLayer) {
 function updateAnyTopicVisibility() {
   const { layers } = map.get('mapbox-style');
   const any = layers.filter((l) => l.metadata?.group === 'any');
-  const visibility = showOverview.value || topics.some((t) => t.visible) ? 'visible' : 'none';
+  const visibility = showOverview.value ? 'visible' : 'none';
   any.forEach((layer) => {
     layer.layout = { ...layer.layout, visibility };
     getLayer(map, layer.id).changed();


### PR DESCRIPTION
Nun ist auch die Übersicht ('any' topic, schraffiert) von den restlichen Ansichten entkoppelt und kann komplett unabhängig über Komponenten gesteuert werden.